### PR TITLE
Specify python3 as the interpreter

### DIFF
--- a/togglecode.py
+++ b/togglecode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import portio
 
 portio.iopl(3)

--- a/zenstates.py
+++ b/zenstates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import struct
 import os
 import glob


### PR DESCRIPTION
The interpreter is specified as `!#/usr/bin/python3` in the scripts for compatibility with legacy systems that _still_ use python2 as the default interpreter, such as ubuntu or debian. This doesn't affects other systems that use python3, e.g. Arch Linux, as the default interpreter since the symlink is there.