### PR TITLE
BIOS fix should be tried first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **If you are looking for a fix regarding random freezes using an AMD Ryzen CPU while idle (mostly Linux - Windows is always busy..) then try fixing it via BIOS settings: CPU/Zen Options in BIOS - "Power Supply Idle Control" or "Global C-state Control" should be set to `Typical current idle` (previous value `Auto` or `Low current idle`.**
+> Sources: [bugzilla.kernel.org](https://bugzilla.kernel.org/show_bug.cgi?id=196683#c194), [Reddit thread](https://www.reddit.com/r/Amd/comments/cik3q1/can_we_recognize_broken_c6_states_in_all_of_zen/)
+
+
 # ZenStates-Linux
 Collection of utilities for Ryzen processors and motherboards
 


### PR DESCRIPTION
But thanks for your script! Not sure if everybody can adjust this in BIOS (maybe some people need an update first?).

Btw C-States look like this now after adjusting the BIOS:
```
$ sudo /usr/local/bin/zenstates.py -l

P0 - Enabled - FID = 88 - DID = 8 - VID = 20 - Ratio = 34.00 - vCore = 1.35000
P1 - Enabled - FID = 78 - DID = 8 - VID = 2C - Ratio = 30.00 - vCore = 1.27500
P2 - Enabled - FID = 84 - DID = C - VID = 68 - Ratio = 22.00 - vCore = 0.90000
P3 - Disabled
P4 - Disabled
P5 - Disabled
P6 - Disabled
P7 - Disabled
C6 State - Package - Disabled
C6 State - Core - Enabled
```
And finally I can idle like a champ ;)